### PR TITLE
[core][WIP] Handle the bootrom and the model during runtime

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,14 +18,8 @@ jobs:
         with:
           submodules: "true"
 
-      - name: Build default
+      - name: Build
         run: cargo build --verbose
 
-      - name: Run default tests
+      - name: Run tests
         run: cargo test --verbose
-
-      - name: Build CGB
-        run: cargo build --verbose --features "cgb"
-
-      - name: Run CGB tests
-        run: cargo test --verbose --features "cgb"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3286b845d0fccbdd15af433f61c5970e711987036cb468f437ff6badd70f4e24"
+checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
 dependencies = [
  "libc",
 ]
@@ -1071,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "281e452d3bad4005426416cdba5ccfd4f5c1280e10099e21db27f7c1c28347fc"
+checksum = "26a147e1a6641a55d994b3e4e9fa4d9b180c8d652c09b363af8c9bf1b8e04139"
 
 [[package]]
 name = "error-iter"
@@ -1821,12 +1821,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
+ "cfg_aliases",
  "libc",
  "memoffset",
 ]
@@ -3582,9 +3583,9 @@ checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
 
 [[package]]
 name = "zbus"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c6ec5949cc90d623c71dffe9ee72f30a0d403b6280e8e27ecc264c4cb2aef2"
+checksum = "c9ff46f2a25abd690ed072054733e0bc3157e3d4c45f41bd183dce09c2ff8ab9"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -3621,9 +3622,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06597bca5fe34637f315d1dd6eba65d337e56afd761e19e91187a69e8b4f6f6"
+checksum = "4e0e3852c93dcdb49c9462afe67a2a468f7bd464150d866e861eaf06208633e0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3666,9 +3667,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "4.0.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a660524eaa9f4a65c673006b034d2167a9a3ef821e9bd7311b2f1c77b904e312"
+checksum = "2c1b3ca6db667bfada0f1ebfc94b2b1759ba25472ee5373d4551bb892616389a"
 dependencies = [
  "endi",
  "enumflags2",
@@ -3680,9 +3681,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "4.0.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b1565fbb82205a83de0bd1293fb2b5c9e34d4e74250fd4aed54903545b1fa2"
+checksum = "b7a4b236063316163b69039f77ce3117accb41a09567fd24c168e43491e521bc"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
+checksum = "3286b845d0fccbdd15af433f61c5970e711987036cb468f437ff6badd70f4e24"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.1"
+version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c764d619ca78fccbf3069b37bd7af92577f044bb15236036662d79b6559f25b7"
+checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "bytemuck"
@@ -1556,9 +1556,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034bbe799d1909622a74d1193aa50147769440040ff36cb2baa947609b0a4e23"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -1914,7 +1914,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.50",
@@ -2145,21 +2145,11 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2683,17 +2673,6 @@ name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow",
-]
 
 [[package]]
 name = "toml_edit"
@@ -3251,7 +3230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -3260,7 +3239,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -3287,7 +3266,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -3322,17 +3301,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.3",
+ "windows_aarch64_msvc 0.52.3",
+ "windows_i686_gnu 0.52.3",
+ "windows_i686_msvc 0.52.3",
+ "windows_x86_64_gnu 0.52.3",
+ "windows_x86_64_gnullvm 0.52.3",
+ "windows_x86_64_msvc 0.52.3",
 ]
 
 [[package]]
@@ -3349,9 +3328,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3367,9 +3346,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3385,9 +3364,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3403,9 +3382,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3421,9 +3400,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3439,9 +3418,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3457,9 +3436,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
 
 [[package]]
 name = "winit"
@@ -3603,9 +3582,9 @@ checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
 
 [[package]]
 name = "zbus"
-version = "4.0.1"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8e3d6ae3342792a6cc2340e4394334c7402f3d793b390d2c5494a4032b3030"
+checksum = "40c6ec5949cc90d623c71dffe9ee72f30a0d403b6280e8e27ecc264c4cb2aef2"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -3642,11 +3621,11 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "4.0.1"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a3e850ff1e7217a3b7a07eba90d37fe9bb9e89a310f718afcde5885ca9b6d7"
+checksum = "d06597bca5fe34637f315d1dd6eba65d337e56afd761e19e91187a69e8b4f6f6"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "regex",
@@ -3687,9 +3666,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e09e8be97d44eeab994d752f341e67b3b0d80512a8b315a0671d47232ef1b65"
+checksum = "a660524eaa9f4a65c673006b034d2167a9a3ef821e9bd7311b2f1c77b904e312"
 dependencies = [
  "endi",
  "enumflags2",
@@ -3701,11 +3680,11 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a5857e2856435331636a9fbb415b09243df4521a267c5bedcd5289b4d5799e"
+checksum = "55b1565fbb82205a83de0bd1293fb2b5c9e34d4e74250fd4aed54903545b1fa2"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,25 +12,36 @@ members = [
 ]
 
 [workspace.lints.clippy]
+# Groups
 pedantic = { level = "warn", priority = -1 }
 nursery = { level = "warn", priority = -1 }
-match_same_arms = "allow"
-cast_lossless = "allow"
-unused_self = "allow"
-similar_names = "allow"
-enum_glob_use = "allow"
-must_use_candidate = "allow"
-missing_panics_doc = "allow"
-missing_errors_doc = "allow"
-collapsible_if = "allow"
+
+# style
 new_without_default = "allow"
-module_name_repetitions = "allow"
-missing_const_for_fn = "allow"
-cast_possible_truncation = "allow"           # Intentional, but may be possible to mitigate.
-verbose_bit_mask = "allow"                   # As per the docs, LLVM may not be able to generate better code.
-cast_possible_wrap = "allow"
-unreadable_literal = "allow"
-option_if_let_else = "allow"                 # This one is annoying and less readable.
+
+# pedantic
+cast_lossless = "allow"            # Noisy and verbose.
+cast_possible_truncation = "allow" # Intentional, but may be possible to mitigate.
+cast_possible_wrap = "allow"       # Used intentionally and extensively.
+collapsible_if = "allow"
+match_same_arms = "allow"
+module_name_repetitions = "allow"  # Annoying.
+must_use_candidate = "allow"       # This one should be fixed.
+similar_names = "allow"            # Nope.
+too_many_lines = "allow"
+unreadable_literal = "allow"       # May not improve readability.
+unused_self = "allow"
+verbose_bit_mask = "allow"         # LLVM generates worse code on x86_64.
+
+# nursery
+enum_variant_names = "allow"   # Annoying.
+missing_const_for_fn = "allow" # Noisy, could address this one.
+option_if_let_else = "allow"   # Annoying and less readable.
+redundant_pub_crate = "allow"  # Some occurrences can be improved.
+
+# Can be addressed by adding documentation.
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
 
 [workspace.dependencies]
 gb-core = { path = "./core/gb-core" }

--- a/core/gb-core-c/Cargo.toml
+++ b/core/gb-core-c/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["staticlib", "dylib"]
 
 [features]
 bootrom = ["gb-core/bootrom"]
-cgb = ["gb-core/cgb"]
 
 [dependencies.gb-core]
 path = "../gb-core"

--- a/core/gb-core-c/Cargo.toml
+++ b/core/gb-core-c/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 workspace = true
 
 [lib]
-crate-type = ["staticlib", "dylib"]
+crate-type = ["dylib", "staticlib"]
 
 [features]
 bootrom = ["gb-core/bootrom"]

--- a/core/gb-core-c/gb-bindings.h
+++ b/core/gb-core-c/gb-bindings.h
@@ -32,7 +32,7 @@ struct GameBoy;
 struct GameBoy* gameboy_new();
 void gameboy_destroy(struct GameBoy* gb_ptr);
 void gameboy_reset(struct GameBoy* gb_ptr);
-void gameboy_load_cartridge(struct GameBoy* gb_ptr, const uint8_t* rom, uintptr_t rom_size);
+void gameboy_insert_cartridge(struct GameBoy* gb_ptr, const uint8_t* rom, uintptr_t rom_size);
 void gameboy_run_frame(struct GameBoy* gb_ptr);
 void gameboy_set_joypad_button(struct GameBoy* gb_ptr, enum Button button, bool value);
 void gameboy_joypad_button_up(struct GameBoy* gb_ptr, enum Button button);

--- a/core/gb-core-c/src/lib.rs
+++ b/core/gb-core-c/src/lib.rs
@@ -41,7 +41,7 @@ pub unsafe extern "C" fn gameboy_reset(gb_ptr: *mut GameBoy) {
 /// 2. The ROM array pointer cannot be null.
 /// 3. The allocated size for the ROM has to be equal to `rom_size`.
 #[no_mangle]
-pub unsafe extern "C" fn gameboy_load_cartridge(
+pub unsafe extern "C" fn gameboy_insert_cartridge(
     gb_ptr: *mut GameBoy,
     rom: *const u8,
     rom_size: usize,
@@ -50,7 +50,8 @@ pub unsafe extern "C" fn gameboy_load_cartridge(
 
     let vec = unsafe { std::slice::from_raw_parts(rom, rom_size).to_vec() };
 
-    gb.load_cartridge(vec).unwrap();
+    gb.insert_bootrom(None);
+    gb.insert_cartridge(vec).unwrap();
 }
 
 /// # Safety

--- a/core/gb-core-c/src/lib.rs
+++ b/core/gb-core-c/src/lib.rs
@@ -1,9 +1,13 @@
 use button::Button;
-use gb_core::{GameBoy, ScreenPixels, SCREEN_HEIGHT, SCREEN_WIDTH};
+use gb_core::{DeviceModel, GameBoy, ScreenPixels, SCREEN_HEIGHT, SCREEN_WIDTH};
 
 #[no_mangle]
-pub extern "C" fn gameboy_new() -> *mut GameBoy {
-    Box::into_raw(Box::new(GameBoy::new()))
+pub extern "C" fn gameboy_new(is_cgb: bool) -> *mut GameBoy {
+    Box::into_raw(Box::new(GameBoy::new(if is_cgb {
+        DeviceModel::Cgb
+    } else {
+        DeviceModel::Dmg
+    })))
 }
 
 /// # Safety

--- a/core/gb-core-wasm/Cargo.toml
+++ b/core/gb-core-wasm/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["cdylib"]
 
 [features]
 bootrom = ["gb-core/bootrom"]
-cgb = ["gb-core/cgb"]
 
 [dependencies]
 console_error_panic_hook = "0.1.7"

--- a/core/gb-core-wasm/src/lib.rs
+++ b/core/gb-core-wasm/src/lib.rs
@@ -1,4 +1,10 @@
-use gb_core::{GameBoy as GameBoyInternal, ScreenPixels, SCREEN_PIXELS_SIZE, SCREEN_WIDTH};
+use gb_core::{
+    DeviceModel,
+    GameBoy as GameBoyInternal,
+    ScreenPixels,
+    SCREEN_PIXELS_SIZE,
+    SCREEN_WIDTH,
+};
 use wasm_bindgen::{prelude::wasm_bindgen, Clamped};
 use web_sys::{CanvasRenderingContext2d, ImageData};
 
@@ -20,7 +26,7 @@ impl GameBoy {
         init_logging();
 
         Self {
-            gb: GameBoyInternal::new(),
+            gb: GameBoyInternal::new(DeviceModel::Dmg),
             frame: vec![0; SCREEN_PIXELS_SIZE]
                 .into_boxed_slice()
                 .try_into()

--- a/core/gb-core-wasm/src/lib.rs
+++ b/core/gb-core-wasm/src/lib.rs
@@ -38,8 +38,9 @@ impl GameBoy {
         self.gb.reset();
     }
 
-    pub fn load_cartridge(&mut self, rom: Vec<u8>) {
-        self.gb.load_cartridge(rom).unwrap();
+    pub fn insert_cartridge(&mut self, rom: Vec<u8>) {
+        self.gb.insert_bootrom(None);
+        self.gb.insert_cartridge(rom).unwrap();
     }
 
     pub fn run_frame(&mut self) {

--- a/core/gb-core/Cargo.toml
+++ b/core/gb-core/Cargo.toml
@@ -7,9 +7,7 @@ edition = "2021"
 workspace = true
 
 [features]
-# default = ["bootrom", "cgb"]
 bootrom = []
-cgb = []
 
 [dependencies]
 arrayvec = "0.7.4"
@@ -20,9 +18,11 @@ paste = "1.0.14"
 thiserror = "1.0.57"
 
 [dev-dependencies]
-image = { version = "0.24.8", default-features = false, features = ["png"] }
+image = { version = "0.24.9", default-features = false, features = ["png"] }
 num = { version = "0.4.1", default-features = false }
+# paste = "1.0.14"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
+thiserror = "1.0.57"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/core/gb-core/Cargo.toml
+++ b/core/gb-core/Cargo.toml
@@ -20,7 +20,6 @@ thiserror = "1.0.57"
 [dev-dependencies]
 image = { version = "0.24.9", default-features = false, features = ["png"] }
 num = { version = "0.4.1", default-features = false }
-# paste = "1.0.14"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
 thiserror = "1.0.57"

--- a/core/gb-core/src/audio copy.rs
+++ b/core/gb-core/src/audio copy.rs
@@ -1,0 +1,117 @@
+// TODO: everything
+
+use crate::{utils::macros::device_is_cgb, DeviceConfig, OptionalCgbComponent};
+
+#[derive(Default)]
+pub struct Audio {
+    device_config: DeviceConfig,
+}
+
+impl OptionalCgbComponent for Audio {
+    fn with_device_config(device_config: DeviceConfig) -> Self {
+        Self { device_config }
+    }
+
+    fn set_device_config(&mut self, device_config: DeviceConfig) {
+        self.device_config = device_config;
+    }
+}
+
+impl Audio {
+    // 0xFF10 ~ 0xFF3F
+
+    // 0xFF10..=0xFF26 => 0, // TODO: Sound.
+    // 0xFF30..=0xFF3F => 0, // TODO: Wave pattern.
+
+    // Undocumented
+    // 0xFF76
+    // 0xFF77
+
+    pub fn read(&self, address: u16) -> u8 {
+        match address {
+            // TODO: stubs for the DMG.
+
+            // Channel 1
+
+            // FF10 — NR10: Channel 1 sweep
+            0xFF10 => 0x80,
+
+            // FF11 — NR11: Channel 1 length timer & duty cycle
+            0xFF11 => 0xBF,
+
+            // FF12 — NR12: Channel 1 volume & envelope
+            0xFF12 => 0xF3,
+
+            // FF13 — NR13: Channel 1 period low [write-only]
+            // 0xFF13 => panic!("NR13 is write-only"),
+
+            // FF14 — NR14: Channel 1 period high & control
+            0xFF14 => 0xBF,
+
+            // Channel 2
+
+            // FF16 — NR21: Channel 2 length timer & duty cycle
+            0xFF16 => 0x3F,
+
+            // FF12 — NR22: Channel 2 volume & envelope
+            0xFF17 => 0x00,
+
+            // FF18 — NR23: Channel 2 period low [write-only]
+            // 0xFF18 => panic!("NR23 is write-only"),
+
+            // FF19 — NR24: Channel 2 period high & control
+            0xFF19 => 0xBF,
+
+            // Channel 3
+
+            // FF1A — NR30: Channel 3 DAC enable
+            0xFF1A => 0x7F,
+
+            // FF1B — NR31: Channel 3 length timer [write-only]
+            // 0xFF1B => panic!("NR31 is write-only"),
+
+            // FF1C — NR32: Channel 3 output level
+            0xFF1C => 0x9F,
+
+            // FF1D — NR33: Channel 3 period low [write-only]
+            // 0xFF1D => panic!("NR33 is write-only"),
+
+            // FF1E — NR34: Channel 3 period high & control
+            0xFF1E => 0xBF,
+
+            0xFF21 => 0x00,
+            0xFF22 => 0x00,
+            0xFF23 => 0xBF,
+
+            // FF24 — NR50: Master volume & VIN panning
+            0xFF24 => 0x77,
+
+            // FF25 — NR51: Sound panning
+            0xFF25 => 0xF3,
+
+            // FF26 — NR52: Audio master control
+            0xFF26 => 0xF1,
+
+            0xFF76 => {
+                if !device_is_cgb!(self) {
+                    return 0xFF;
+                }
+
+                0x00
+            }
+
+            0xFF77 => {
+                if !device_is_cgb!(self) {
+                    return 0xFF;
+                }
+
+                0x00
+            }
+
+            // _ => panic!("Invalid address"),
+            _ => 0xFF,
+        }
+    }
+
+    pub fn write(&mut self, _address: u16, _value: u8) {}
+}

--- a/core/gb-core/src/audio.rs
+++ b/core/gb-core/src/audio.rs
@@ -1,9 +1,26 @@
 // TODO: everything
 
-use crate::utils::macros::device_is_cgb;
+use crate::{utils::macros::device_is_cgb, DeviceConfig, DeviceModel, OptionalCgbComponent};
 
 #[derive(Default)]
-pub struct Audio {}
+pub struct Audio {
+    device_config: DeviceConfig,
+}
+
+impl OptionalCgbComponent for Audio {
+    fn with_device_model(model: DeviceModel) -> Self {
+        let device_config = DeviceConfig {
+            model,
+            ..Default::default()
+        };
+
+        Self { device_config }
+    }
+
+    fn set_cgb_mode(&mut self, value: bool) {
+        self.device_config.cgb_mode = value;
+    }
+}
 
 impl Audio {
     // 0xFF10 ~ 0xFF3F
@@ -36,7 +53,7 @@ impl Audio {
             0xFF26 => 0xF1,
 
             0xFF76 => {
-                if !device_is_cgb!() {
+                if !device_is_cgb!(self) {
                     return 0xFF;
                 }
 
@@ -44,7 +61,7 @@ impl Audio {
             }
 
             0xFF77 => {
-                if !device_is_cgb!() {
+                if !device_is_cgb!(self) {
                     return 0xFF;
                 }
 

--- a/core/gb-core/src/constants.rs
+++ b/core/gb-core/src/constants.rs
@@ -7,10 +7,10 @@ pub const SCREEN_HEIGHT: usize = 144;
 
 pub const SCREEN_PIXELS_SIZE: usize = SCREEN_WIDTH * SCREEN_HEIGHT * std::mem::size_of::<u32>();
 
-#[cfg(not(feature = "cgb"))]
-pub const TILE_DATA_FRAME_WIDTH: usize = 128;
+// #[cfg(not(feature = "cgb"))]
+// pub const TILE_DATA_FRAME_WIDTH: usize = 128;
 
-#[cfg(feature = "cgb")]
+// #[cfg(feature = "cgb")]
 pub const TILE_DATA_FRAME_WIDTH: usize = 128 * 2;
 
 pub const TILE_DATA_FRAME_HEIGHT: usize = 192;

--- a/core/gb-core/src/constants.rs
+++ b/core/gb-core/src/constants.rs
@@ -23,3 +23,31 @@ pub type TileDataFrame = [u8; TILE_DATA_FRAME_SIZE];
 
 pub const EXTENSIONS_DESCRIPTION: &str = "Game Boy/Game Boy Color ROM";
 pub const EXTENSIONS: [&str; 2] = ["gb", "gbc"];
+
+pub(crate) trait OptionalCgbComponent {
+    fn with_device_model(model: DeviceModel) -> Self;
+    fn set_cgb_mode(&mut self, value: bool);
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum DeviceModel {
+    #[default]
+    Dmg,
+    Cgb,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DeviceConfig {
+    pub model: DeviceModel,
+    pub cgb_mode: bool,
+}
+
+impl DeviceConfig {
+    pub fn is_cgb(&self) -> bool {
+        self.model == DeviceModel::Cgb
+    }
+
+    pub fn in_cgb_mode(&self) -> bool {
+        self.is_cgb() && self.cgb_mode
+    }
+}

--- a/core/gb-core/src/cpu.rs
+++ b/core/gb-core/src/cpu.rs
@@ -1,11 +1,36 @@
 use self::registers::{ImeState, Registers};
-use crate::{memory::MemoryInterface, utils::macros::device_is_cgb};
+use crate::{
+    memory::MemoryInterface,
+    utils::macros::device_is_cgb,
+    DeviceConfig,
+    DeviceModel,
+    OptionalCgbComponent,
+};
 
 #[derive(Default)]
 pub struct Cpu {
     registers: Registers,
     halt: bool,
     pub cycles: i32,
+    device_config: DeviceConfig,
+}
+
+impl OptionalCgbComponent for Cpu {
+    fn with_device_model(model: DeviceModel) -> Self {
+        let device_config = DeviceConfig {
+            model,
+            ..Default::default()
+        };
+
+        Self {
+            device_config,
+            ..Default::default()
+        }
+    }
+
+    fn set_cgb_mode(&mut self, value: bool) {
+        self.device_config.cgb_mode = value;
+    }
 }
 
 impl Cpu {
@@ -17,7 +42,7 @@ impl Cpu {
         self.registers.pc = 0x0100;
         self.registers.sp = 0xFFFE;
 
-        if device_is_cgb!() {
+        if device_is_cgb!(self) {
             self.registers.set_af(0x1180);
             self.registers.set_bc(0x0000);
             self.registers.set_de(0x0008);

--- a/core/gb-core/src/cpu/instructions.rs
+++ b/core/gb-core/src/cpu/instructions.rs
@@ -2,7 +2,6 @@ use super::Cpu;
 use crate::memory::MemoryInterface;
 
 impl Cpu {
-    #[allow(clippy::too_many_lines)]
     pub(super) fn run_instruction(&mut self, memory: &mut impl MemoryInterface, opcode: u8) {
         match opcode {
             0x00 => self.opcode_0x00(),
@@ -264,7 +263,6 @@ impl Cpu {
         }
     }
 
-    #[allow(clippy::too_many_lines)]
     pub(super) fn run_cb_instruction(&mut self, memory: &mut impl MemoryInterface, opcode: u8) {
         match opcode {
             0x00 => self.opcode_cb_0x00(),

--- a/core/gb-core/src/lib.rs
+++ b/core/gb-core/src/lib.rs
@@ -11,20 +11,15 @@ pub use utils::{button::Button, color::Color};
 pub struct GameBoy {
     cpu: Cpu,
     memory: Memory,
-
     rom: Option<Arc<Box<[u8]>>>,
-}
 
-impl Default for GameBoy {
-    fn default() -> Self {
-        Self::new()
-    }
+    pub device_model: DeviceModel,
 }
 
 impl GameBoy {
-    pub fn new() -> Self {
-        let mut cpu = Cpu::default();
-        let mut memory = Memory::default();
+    pub fn new(device_model: DeviceModel) -> Self {
+        let mut cpu = Cpu::with_device_model(device_model);
+        let mut memory = Memory::with_device_model(device_model);
 
         if !cfg!(feature = "bootrom") {
             cpu.skip_bootrom();
@@ -35,6 +30,7 @@ impl GameBoy {
             cpu,
             memory,
             rom: None,
+            device_model,
         }
     }
 
@@ -130,7 +126,7 @@ impl GameBoy {
 }
 
 mod audio;
-mod cartridge;
+pub mod cartridge;
 mod constants;
 mod cpu;
 mod joypad;

--- a/core/gb-core/src/memory.rs
+++ b/core/gb-core/src/memory.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use log::info;
+
 use self::{
     bootrom::Bootrom,
     high_ram::HighRam,
@@ -391,7 +393,7 @@ impl Memory {
         let cartridge = Cartridge::new(rom)?;
 
         if device_is_cgb!(self) {
-            if cfg!(feature = "bootrom") {
+            if self.bootrom.is_loaded() {
                 self.set_cgb_mode(true);
             } else {
                 self.handle_post_bootrom_setup(&cartridge.info);
@@ -401,6 +403,11 @@ impl Memory {
         self.cartridge = Some(cartridge);
 
         Ok(())
+    }
+
+    pub(crate) fn use_bootrom(&mut self, bootrom: Arc<Box<[u8]>>) {
+        self.bootrom.insert(self.device_config.model, bootrom);
+        info!("Bootrom loaded.");
     }
 
     pub(crate) fn skip_bootrom(&mut self) {

--- a/core/gb-core/src/memory.rs
+++ b/core/gb-core/src/memory.rs
@@ -20,6 +20,9 @@ use crate::{
     serial::Serial,
     timer::Timer,
     utils::macros::{device_is_cgb, in_cgb_mode},
+    DeviceConfig,
+    DeviceModel,
+    OptionalCgbComponent,
 };
 
 pub trait MemoryInterface {
@@ -59,7 +62,7 @@ pub struct Memory {
 
     undocumented_registers: UndocumentedRegisters,
 
-    cgb_mode: bool,
+    device_config: DeviceConfig,
 }
 
 impl MemoryInterface for Memory {
@@ -71,8 +74,9 @@ impl MemoryInterface for Memory {
         match address {
             0x0000..=0x00FF if self.bootrom.is_active() => self.bootrom.read(address),
 
-            #[cfg(feature = "cgb")]
-            0x0200..=0x08FF if self.bootrom.is_active() => self.bootrom.read(address),
+            0x0200..=0x08FF if self.bootrom.is_active() && device_is_cgb!(self) => {
+                self.bootrom.read(address)
+            }
 
             0x0000..=0x3FFF => self
                 .cartridge
@@ -305,6 +309,42 @@ impl MemoryInterface for Memory {
     }
 }
 
+impl OptionalCgbComponent for Memory {
+    fn with_device_model(model: DeviceModel) -> Self {
+        let device_config = DeviceConfig {
+            model,
+            ..Default::default()
+        };
+
+        let wram = WorkRam::with_device_model(model);
+        let ppu = Ppu::with_device_model(model);
+        let speed_switch = SpeedSwitch::with_device_model(model);
+        let undocumented_registers = UndocumentedRegisters::with_device_model(model);
+
+        Self {
+            wram,
+            ppu,
+            speed_switch,
+            undocumented_registers,
+            device_config,
+            ..Default::default()
+        }
+    }
+
+    fn set_cgb_mode(&mut self, value: bool) {
+        log::info!("{} CGB mode.", if value { "Enabling" } else { "Disabling" });
+
+        assert!(self.device_config.model == DeviceModel::Cgb);
+
+        self.wram.set_cgb_mode(value);
+        self.ppu.set_cgb_mode(value);
+        self.speed_switch.set_cgb_mode(value);
+        self.undocumented_registers.set_cgb_mode(value);
+
+        self.device_config.cgb_mode = value;
+    }
+}
+
 impl Memory {
     fn cycle(&mut self) {
         // TODO: properly implement double speed.
@@ -350,7 +390,7 @@ impl Memory {
     pub(crate) fn load_cartridge(&mut self, rom: Arc<Box<[u8]>>) -> Result<(), CartridgeError> {
         let cartridge = Cartridge::new(rom)?;
 
-        if device_is_cgb!() {
+        if device_is_cgb!(self) {
             if cfg!(feature = "bootrom") {
                 self.set_cgb_mode(true);
             } else {
@@ -361,17 +401,6 @@ impl Memory {
         self.cartridge = Some(cartridge);
 
         Ok(())
-    }
-
-    pub(crate) fn set_cgb_mode(&mut self, value: bool) {
-        log::info!("{} CGB mode.", if value { "Enabling" } else { "Disabling" });
-
-        self.cgb_mode = value;
-
-        self.wram.set_cgb_mode(value);
-        self.ppu.set_cgb_mode(value);
-        self.speed_switch.set_cgb_mode(value);
-        self.undocumented_registers.set_cgb_mode(value);
     }
 
     pub(crate) fn skip_bootrom(&mut self) {

--- a/core/gb-core/src/memory/bootrom.rs
+++ b/core/gb-core/src/memory/bootrom.rs
@@ -1,58 +1,91 @@
-#[cfg(all(feature = "bootrom", not(feature = "cgb")))]
+use std::sync::Arc;
+
+use crate::DeviceModel;
+
 /// DMG
 ///
 /// Size: 256 (0x100)
-const BOOTROM_SIZE: usize = 0x100;
+const DMG_BOOTROM_SIZE: usize = 0x100;
 
-#[cfg(all(feature = "bootrom", feature = "cgb"))]
 /// CGB
 ///
 /// Size: 256 + 256 + 1792  = 2304 (0x900)
 ///
 /// Note: the extra 256 bytes in the middle is mapped to the cartridge header until 0x200.
-const BOOTROM_SIZE: usize = 0x100 + 0x100 + 0x700;
+const CGB_BOOTROM_SIZE: usize = 0x100 + 0x100 + 0x700;
 
-#[cfg(feature = "bootrom")]
+// #[cfg(feature = "bootrom")]
+#[derive(Default)]
 pub struct Bootrom {
-    data: &'static [u8; BOOTROM_SIZE],
+    data: Option<Arc<Box<[u8]>>>,
     is_active: bool,
 }
 
-#[cfg(feature = "bootrom")]
-impl Default for Bootrom {
+// TODO: optional feature to bundle the bootrom
+// #[cfg(feature = "bootrom")]
+/* impl Default for Bootrom {
     fn default() -> Self {
-        #[cfg(not(feature = "cgb"))]
-        let data = include_bytes!("../../../../roms/bootrom/dmg_boot.bin");
+        // #[cfg(not(feature = "cgb"))]
+        // let data = include_bytes!("../../../../roms/bootrom/dmg_boot.bin");
 
-        #[cfg(feature = "cgb")]
-        let data = include_bytes!("../../../../roms/bootrom/cgb_boot.bin");
+        // #[cfg(feature = "cgb")]
+        // let data = include_bytes!("../../../../roms/bootrom/cgb_boot.bin");
 
         Self {
             data,
             is_active: true,
         }
     }
-}
+} */
 
-#[cfg(feature = "bootrom")]
 impl Bootrom {
+    pub fn insert(&mut self, device_model: DeviceModel, bootrom: Arc<Box<[u8]>>) {
+        match device_model {
+            DeviceModel::Dmg => assert_eq!(bootrom.len(), DMG_BOOTROM_SIZE),
+            DeviceModel::Cgb => assert_eq!(bootrom.len(), CGB_BOOTROM_SIZE),
+        };
+
+        self.data = Some(bootrom);
+        self.is_active = true;
+    }
+
+    pub fn is_loaded(&self) -> bool {
+        self.data.is_some()
+    }
+
     pub fn is_active(&self) -> bool {
         self.is_active
     }
 
     pub fn disable(&mut self) {
+        if self.data.is_none() {
+            return;
+        }
+
         self.is_active = false;
     }
 
     pub fn read(&self, address: u16) -> u8 {
-        self.data[address as usize]
+        if let Some(data) = &self.data {
+            data[address as usize]
+        } else {
+            0xFF
+        }
     }
 
     pub fn read_status(&self) -> u8 {
+        if self.data.is_none() {
+            return 0xFF;
+        }
+
         0b1111_1110 | (!self.is_active as u8)
     }
 
     pub fn write_status(&mut self, value: u8) {
+        if self.data.is_none() {
+            return;
+        }
+
         if !self.is_active {
             // Locked.
             return;
@@ -60,30 +93,4 @@ impl Bootrom {
 
         self.is_active = (value & 0b1) == 0;
     }
-}
-
-// Stubs for when bootrom support is disabled.
-
-#[cfg(not(feature = "bootrom"))]
-#[derive(Debug, Default)]
-/// Bootrom stubs
-pub struct Bootrom {}
-
-#[cfg(not(feature = "bootrom"))]
-impl Bootrom {
-    pub fn is_active(&self) -> bool {
-        false
-    }
-
-    pub fn disable(&self) {}
-
-    pub fn read(&self, _address: u16) -> u8 {
-        0xFF
-    }
-
-    pub fn read_status(&self) -> u8 {
-        0xFF
-    }
-
-    pub fn write_status(&self, _value: u8) {}
 }

--- a/core/gb-core/src/memory/speed_switch.rs
+++ b/core/gb-core/src/memory/speed_switch.rs
@@ -60,70 +60,70 @@ impl SpeedSwitch {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::macros::device_is_cgb;
 
     #[test]
-    fn test_my_sanity() {
-        let mut speed_switch = SpeedSwitch::default();
+    fn test_my_sanity_dmg() {
+        let mut speed_switch = SpeedSwitch::with_device_model(DeviceModel::Dmg);
 
-        if device_is_cgb!(speed_switch) {
-            // speed_switch.set_cgb_mode(true);
-
-            assert_eq!(speed_switch.read(), 0b0111_1110);
-
-            speed_switch.write(0xFF);
-            assert_eq!(speed_switch.read(), 0b0111_1111);
-        } else {
-            assert_eq!(speed_switch.read(), 0xFF);
-            speed_switch.write(0xFF);
-            assert_eq!(speed_switch.read(), 0xFF);
-        }
+        assert_eq!(speed_switch.read(), 0xFF);
+        speed_switch.write(0xFF);
+        assert_eq!(speed_switch.read(), 0xFF);
     }
 
     #[test]
-    #[cfg(feature = "cgb")]
+    fn test_my_sanity_cgb() {
+        let mut speed_switch = SpeedSwitch::with_device_model(DeviceModel::Cgb);
+        speed_switch.set_cgb_mode(true);
+
+        assert_eq!(speed_switch.read(), 0b0111_1110);
+
+        speed_switch.write(0xFF);
+        assert_eq!(speed_switch.read(), 0b0111_1111);
+    }
+
+    #[test]
     fn test_switch() {
-        let mut speed_switch = SpeedSwitch::default();
+        let mut speed_switch = SpeedSwitch::with_device_model(DeviceModel::Cgb);
         speed_switch.set_cgb_mode(true);
 
         assert_eq!(speed_switch.key0, 0);
         assert_eq!(speed_switch.read(), 0b0111_1110);
-        assert_eq!(speed_switch.in_double_speed(), false);
+        assert!(!speed_switch.in_double_speed());
 
         // No changes.
         speed_switch.write(0b1111_1110);
         assert_eq!(speed_switch.key0, 0);
         assert_eq!(speed_switch.read(), 0b0111_1110);
-        assert_eq!(speed_switch.in_double_speed(), false);
+        assert!(!speed_switch.in_double_speed());
 
         // No changes.
         speed_switch.process_speed_switch();
         assert_eq!(speed_switch.key0, 0);
         assert_eq!(speed_switch.read(), 0b0111_1110);
-        assert_eq!(speed_switch.in_double_speed(), false);
+        assert!(!speed_switch.in_double_speed());
 
         // Request speed switch (Single -> Double).
         speed_switch.write(0b1111_1111);
         assert_eq!(speed_switch.key0, 0b1);
         assert_eq!(speed_switch.read(), 0b0111_1111);
-        assert_eq!(speed_switch.in_double_speed(), false);
+        assert!(!speed_switch.in_double_speed());
 
         // Process speed switch (Single -> Double).
         speed_switch.process_speed_switch();
         assert_eq!(speed_switch.key0, 0b1000_0000);
         assert_eq!(speed_switch.read(), 0b1111_1110);
-        assert_eq!(speed_switch.in_double_speed(), true);
+        assert!(speed_switch.in_double_speed());
 
         // Request speed switch (Double -> Single).
         speed_switch.write(0b1111_1111);
         assert_eq!(speed_switch.key0, 0b1000_0001);
         assert_eq!(speed_switch.read(), 0b1111_1111);
-        assert_eq!(speed_switch.in_double_speed(), true);
+        assert!(speed_switch.in_double_speed());
 
         // Process speed switch (Double -> Single).
         speed_switch.process_speed_switch();
         assert_eq!(speed_switch.key0, 0b0000_0000);
         assert_eq!(speed_switch.read(), 0b0111_1110);
-        assert_eq!(speed_switch.in_double_speed(), false);
+        assert!(!speed_switch.in_double_speed());
     }
 }

--- a/core/gb-core/src/memory/speed_switch.rs
+++ b/core/gb-core/src/memory/speed_switch.rs
@@ -1,17 +1,31 @@
-use crate::utils::macros::in_cgb_mode;
+use crate::{utils::macros::in_cgb_mode, DeviceConfig, DeviceModel, OptionalCgbComponent};
 
 #[derive(Debug, Default)]
 pub struct SpeedSwitch {
     key0: u8,
 
-    cgb_mode: bool,
+    device_config: DeviceConfig,
+}
+
+impl OptionalCgbComponent for SpeedSwitch {
+    fn with_device_model(model: DeviceModel) -> Self {
+        let device_config = DeviceConfig {
+            model,
+            ..Default::default()
+        };
+
+        Self {
+            device_config,
+            ..Default::default()
+        }
+    }
+
+    fn set_cgb_mode(&mut self, value: bool) {
+        self.device_config.cgb_mode = value;
+    }
 }
 
 impl SpeedSwitch {
-    pub fn set_cgb_mode(&mut self, value: bool) {
-        self.cgb_mode = value;
-    }
-
     pub fn in_double_speed(&self) -> bool {
         (self.key0 & 0b1000_0000) != 0
     }
@@ -52,8 +66,8 @@ mod tests {
     fn test_my_sanity() {
         let mut speed_switch = SpeedSwitch::default();
 
-        if device_is_cgb!() {
-            speed_switch.set_cgb_mode(true);
+        if device_is_cgb!(speed_switch) {
+            // speed_switch.set_cgb_mode(true);
 
             assert_eq!(speed_switch.read(), 0b0111_1110);
 

--- a/core/gb-core/src/memory/undocumented_registers.rs
+++ b/core/gb-core/src/memory/undocumented_registers.rs
@@ -1,4 +1,9 @@
-use crate::utils::macros::{device_is_cgb, in_cgb_mode};
+use crate::{
+    utils::macros::{device_is_cgb, in_cgb_mode},
+    DeviceConfig,
+    DeviceModel,
+    OptionalCgbComponent,
+};
 
 #[derive(Debug, Default)]
 pub struct UndocumentedRegisters {
@@ -7,18 +12,32 @@ pub struct UndocumentedRegisters {
     reg_0xff74: u8,
     reg_0xff75: u8,
 
-    cgb_mode: bool,
+    device_config: DeviceConfig,
+}
+
+impl OptionalCgbComponent for UndocumentedRegisters {
+    fn with_device_model(model: DeviceModel) -> Self {
+        let device_config = DeviceConfig {
+            model,
+            ..Default::default()
+        };
+
+        Self {
+            device_config,
+            ..Default::default()
+        }
+    }
+
+    fn set_cgb_mode(&mut self, value: bool) {
+        self.device_config.cgb_mode = value;
+    }
 }
 
 impl UndocumentedRegisters {
     const REG_FF75_MASK: u8 = 0b0111_0000;
 
-    pub fn set_cgb_mode(&mut self, value: bool) {
-        self.cgb_mode = value;
-    }
-
     pub fn read_0xff72(&self) -> u8 {
-        if !device_is_cgb!() {
+        if !device_is_cgb!(self) {
             return 0xFF;
         }
 
@@ -26,7 +45,7 @@ impl UndocumentedRegisters {
     }
 
     pub fn read_0xff73(&self) -> u8 {
-        if !device_is_cgb!() {
+        if !device_is_cgb!(self) {
             return 0xFF;
         }
 
@@ -42,7 +61,7 @@ impl UndocumentedRegisters {
     }
 
     pub fn read_0xff75(&self) -> u8 {
-        if !device_is_cgb!() {
+        if !device_is_cgb!(self) {
             return 0xFF;
         }
 
@@ -50,7 +69,7 @@ impl UndocumentedRegisters {
     }
 
     pub fn write_0xff72(&mut self, value: u8) {
-        if !device_is_cgb!() {
+        if !device_is_cgb!(self) {
             return;
         }
 
@@ -58,7 +77,7 @@ impl UndocumentedRegisters {
     }
 
     pub fn write_0xff73(&mut self, value: u8) {
-        if !device_is_cgb!() {
+        if !device_is_cgb!(self) {
             return;
         }
 
@@ -74,7 +93,7 @@ impl UndocumentedRegisters {
     }
 
     pub fn write_0xff75(&mut self, value: u8) {
-        if !device_is_cgb!() {
+        if !device_is_cgb!(self) {
             return;
         }
 

--- a/core/gb-core/src/ppu/draw_line_cgb.rs
+++ b/core/gb-core/src/ppu/draw_line_cgb.rs
@@ -1,7 +1,8 @@
-#![cfg(feature = "cgb")]
-
 use super::Ppu;
-use crate::{constants::SCREEN_WIDTH, utils::color::Color};
+use crate::{
+    constants::SCREEN_WIDTH,
+    utils::{color::Color, macros::in_cgb_mode},
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Priority {
@@ -11,6 +12,7 @@ enum Priority {
 }
 
 impl Ppu {
+    /// Warning: CGB model only.
     pub(super) fn draw_line_cgb(&mut self) {
         let mut priority = [Priority::Object; SCREEN_WIDTH];
 
@@ -27,7 +29,7 @@ impl Ppu {
         };
 
         let should_render_win = self.lcdc.get_win_enable() && self.wy <= self.ly;
-        let should_render_bg = self.cgb_mode || self.lcdc.get_bg_enable();
+        let should_render_bg = in_cgb_mode!(self) || self.lcdc.get_bg_enable();
 
         let window_x = self.wx.saturating_sub(7);
 
@@ -55,7 +57,7 @@ impl Ppu {
 
                 (x, y, tile_map_base_address)
             } else {
-                let pixel = Color::SYSTEM_DEFAULT;
+                let pixel = Color::CGB_SYSTEM_DEFAULT;
 
                 screen_line[i as usize] = pixel;
 
@@ -70,7 +72,7 @@ impl Ppu {
             };
 
             let tile_map_attributes = {
-                if self.cgb_mode {
+                if in_cgb_mode!(self) {
                     self.vram.read_bank_1(tile_map_address)
                 } else {
                     0
@@ -136,7 +138,7 @@ impl Ppu {
                 (hi << 1) | lo
             };
 
-            if self.cgb_mode {
+            if in_cgb_mode!(self) {
                 let raw_color = self.bg_cram.get_color_rgb555(palette_number, color_id);
 
                 if color_id == 0 || !self.lcdc.get_bg_enable() {
@@ -249,7 +251,7 @@ impl Ppu {
                     continue;
                 }
 
-                if self.cgb_mode {
+                if in_cgb_mode!(self) {
                     if !(priority[mapped_x] == Priority::Object
                         || (priority[mapped_x] == Priority::OamAttribute
                             && !sprite.flags.bg_priority))

--- a/core/gb-core/src/ppu/draw_line_cgb.rs
+++ b/core/gb-core/src/ppu/draw_line_cgb.rs
@@ -20,7 +20,6 @@ impl Ppu {
         self.draw_sprites_cgb(&priority);
     }
 
-    #[allow(clippy::too_many_lines)]
     fn draw_tiles_cgb(&mut self, priority: &mut [Priority; SCREEN_WIDTH]) {
         let screen_line = {
             let line_offset = SCREEN_WIDTH * (self.ly as usize);

--- a/core/gb-core/src/ppu/draw_line_dmg.rs
+++ b/core/gb-core/src/ppu/draw_line_dmg.rs
@@ -45,7 +45,7 @@ impl Ppu {
 
                 (x, y, tile_map_base_address)
             } else {
-                let pixel = Color::SYSTEM_DEFAULT;
+                let pixel = Color::DMG_SYSTEM_DEFAULT;
 
                 screen_line[i as usize] = pixel;
 

--- a/core/gb-core/src/ppu/lcd_control.rs
+++ b/core/gb-core/src/ppu/lcd_control.rs
@@ -1,7 +1,7 @@
 use bitflags::bitflags;
 
 use super::{lcd_status::StatusMode, Ppu};
-use crate::utils::color::Color;
+use crate::utils::{color::Color, macros::device_is_cgb};
 
 bitflags!(
     /// FF40 — LCDC: LCD control
@@ -115,7 +115,11 @@ impl Ppu {
             self.cycles = 0;
             self.ly = 0;
 
-            self.internal_screen.screen.fill(Color::SYSTEM_DEFAULT);
+            if device_is_cgb!(self) {
+                self.internal_screen.screen.fill(Color::CGB_SYSTEM_DEFAULT);
+            } else {
+                self.internal_screen.screen.fill(Color::DMG_SYSTEM_DEFAULT);
+            }
         }
 
         self.lcdc = new_lcdc;

--- a/core/gb-core/src/ppu/oam.rs
+++ b/core/gb-core/src/ppu/oam.rs
@@ -47,7 +47,8 @@ impl Oam {
     ///
     /// This is the default behaviour in the CGB, but the bootrom can change this
     /// by modifying the OPRI (0xFF6C) register.
-    #[cfg(feature = "cgb")]
+    ///
+    /// Warning: CGB model only.
     pub fn get_sprites_in_line_by_oam(&mut self, ly: u8, obj_height: u8) -> &[SpriteObject] {
         self.update_sprite_buffer(ly, obj_height);
 

--- a/core/gb-core/src/ppu/video_ram.rs
+++ b/core/gb-core/src/ppu/video_ram.rs
@@ -189,7 +189,7 @@ mod tests {
     use super::*;
 
     #[test]
-    #[ignore = "need to adjust this"]
+    #[ignore = "maybe adjust this?"]
     fn test_my_sanity_dmg() {
         let vram = VideoRam::with_device_model(DeviceModel::Dmg);
         assert_eq!(vram.data.len(), 0x2000);
@@ -202,14 +202,13 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "cgb")]
     fn test_read_banks() {
-        let mut vram = VideoRam::default();
+        let mut vram = VideoRam::with_device_model(DeviceModel::Cgb);
         vram.set_cgb_mode(true);
 
         let chunks = vram.data.chunks_exact_mut(VRAM_BANK_SIZE);
 
-        assert_eq!(chunks.len(), VRAM_BANKS); // 2 banks
+        assert_eq!(chunks.len(), CGB_VRAM_BANKS); // 2 banks
 
         for (bank, chunk) in chunks.enumerate() {
             let chunk_iter = chunk.iter_mut();
@@ -225,9 +224,8 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "cgb")]
     fn test_write_banks() {
-        let mut vram = VideoRam::default();
+        let mut vram = VideoRam::with_device_model(DeviceModel::Cgb);
         vram.set_cgb_mode(true);
 
         // Bank 0
@@ -246,8 +244,10 @@ mod tests {
         verify_banks(&mut vram);
     }
 
-    #[cfg(feature = "cgb")]
+    #[allow(clippy::identity_op)]
     fn verify_banks(vram: &mut VideoRam) {
+        assert!(vram.device_config.in_cgb_mode());
+
         // Bank 0
         vram.write_vbk(0b1111_1110 | 0b0);
         assert_eq!(vram.vbk, 0b0, "Should ignore bits 1-7");

--- a/core/gb-core/src/ppu/vram_dma.rs
+++ b/core/gb-core/src/ppu/vram_dma.rs
@@ -47,8 +47,7 @@ impl VramDma {
     /// HDMA5 (length/mode/start)
     pub fn read_hdma5(&self) -> u8 {
         match self.mode {
-            DmaMode::Idle => 0xFF,
-            DmaMode::General => 0xFF,
+            DmaMode::Idle | DmaMode::General => 0xFF,
 
             DmaMode::Hblank {
                 remaining_steps, ..

--- a/core/gb-core/src/utils/color.rs
+++ b/core/gb-core/src/utils/color.rs
@@ -6,11 +6,9 @@ pub struct Color {
 }
 
 impl Color {
+    pub const CGB_SYSTEM_DEFAULT: Self = Self::WHITE_RGB555;
     pub const DMG_PALETTE: [u8; 4] = [0xFF, 0xAA, 0x55, 0x00];
-    #[cfg(not(feature = "cgb"))]
-    pub const SYSTEM_DEFAULT: Self = Self::WHITE;
-    #[cfg(feature = "cgb")]
-    pub const SYSTEM_DEFAULT: Self = Self::WHITE_RGB555;
+    pub const DMG_SYSTEM_DEFAULT: Self = Self::WHITE;
     pub const WHITE: Self = Self::new(0xFF, 0xFF, 0xFF);
     pub const WHITE_RGB555: Self =
         Self::from_rgb555_u16_to_rgba8888((0x7F << 10) | (0x7F << 5) | 0x7F);

--- a/core/gb-core/src/utils/macros.rs
+++ b/core/gb-core/src/utils/macros.rs
@@ -18,14 +18,14 @@ macro_rules! pure_read_write_methods_u8 {
 }
 
 macro_rules! device_is_cgb {
-    () => {
-        cfg!(feature = "cgb")
+    ($self:ident) => {
+        $self.device_config.is_cgb()
     };
 }
 
 macro_rules! in_cgb_mode {
     ($self:ident) => {
-        (cfg!(feature = "cgb") && $self.cgb_mode)
+        $self.device_config.in_cgb_mode()
     };
 }
 

--- a/core/gb-core/src/utils/screen.rs
+++ b/core/gb-core/src/utils/screen.rs
@@ -14,7 +14,7 @@ impl Default for Screen {
 impl Screen {
     pub fn new() -> Self {
         Self {
-            screen: vec![Color::SYSTEM_DEFAULT; SCREEN_WIDTH * SCREEN_HEIGHT]
+            screen: vec![Color::default(); SCREEN_WIDTH * SCREEN_HEIGHT]
                 .into_boxed_slice()
                 .try_into()
                 .unwrap(),

--- a/core/gb-core/tests/blargg.rs
+++ b/core/gb-core/tests/blargg.rs
@@ -1,6 +1,3 @@
-use common::runners::{run_until_memory_status, run_until_serial_passed};
-use gb_core::GameBoy;
-
 mod common;
 
 testcases_blargg_serial! {

--- a/core/gb-core/tests/cgb_acid2.rs
+++ b/core/gb-core/tests/cgb_acid2.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "cgb")]
-
 use common::{runners::run_until_break, validators::validate_screenshot};
 use gb_core::GameBoy;
 
@@ -10,9 +8,9 @@ fn test_cgb_acid2() {
     let name = "cgb-acid2";
     let rom = include_bytes!("../../../external/gameboy-test-roms/cgb-acid2.gbc");
 
-    let mut gb = GameBoy::new();
+    let mut gb = GameBoy::new(gb_core::DeviceModel::Cgb);
     gb.load_cartridge(rom.to_vec()).unwrap();
 
-    run_until_break(&mut gb);
-    validate_screenshot(&gb, name);
+    run_until_break(&mut gb).unwrap();
+    validate_screenshot(&gb, name).unwrap();
 }

--- a/core/gb-core/tests/cgb_acid2.rs
+++ b/core/gb-core/tests/cgb_acid2.rs
@@ -9,7 +9,8 @@ fn test_cgb_acid2() {
     let rom = include_bytes!("../../../external/gameboy-test-roms/cgb-acid2.gbc");
 
     let mut gb = GameBoy::new(gb_core::DeviceModel::Cgb);
-    gb.load_cartridge(rom.to_vec()).unwrap();
+    gb.insert_bootrom(None);
+    gb.insert_cartridge(rom.to_vec()).unwrap();
 
     run_until_break(&mut gb).unwrap();
     validate_screenshot(&gb, name).unwrap();

--- a/core/gb-core/tests/common/blargg.rs
+++ b/core/gb-core/tests/common/blargg.rs
@@ -1,0 +1,22 @@
+use gb_core::DeviceModel;
+
+use super::{
+    error::Error,
+    runners::{run_test, run_until_memory_status, run_until_serial_passed},
+};
+
+pub fn run_serial(model: DeviceModel, rom: &'static [u8]) -> Result<(), Error> {
+    run_test(model, rom, |gb| {
+        run_until_serial_passed(gb)?;
+
+        Ok(())
+    })
+}
+
+pub fn run_memory(model: DeviceModel, rom: &'static [u8]) -> Result<(), Error> {
+    run_test(model, rom, |gb| {
+        run_until_memory_status(gb)?;
+
+        Ok(())
+    })
+}

--- a/core/gb-core/tests/common/error.rs
+++ b/core/gb-core/tests/common/error.rs
@@ -1,0 +1,19 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Timed out.")]
+    Timeout,
+    #[error("The test reported an error {0}.")]
+    MemoryOutputFailure(String),
+    #[error("The test reported an error {0}.")]
+    SerialOutputFailure(String),
+    #[error("Assertion failed. The Fibonacci valitation failed.")]
+    FibonacciValidationFailure,
+    #[error("Assertion failed. The snapshot does not match the expected one.")]
+    SnapshotMismatch,
+    #[error("Cartridge error: {0:?}")]
+    CartridgeError(#[from] gb_core::cartridge::error::Error),
+    #[error("Internal image error: {0:?}")]
+    ImageError(#[from] image::ImageError),
+}

--- a/core/gb-core/tests/common/macros.rs
+++ b/core/gb-core/tests/common/macros.rs
@@ -1,93 +1,76 @@
 #[macro_export]
+macro_rules! run_for_model {
+    ($F:path, $rom:ident) => {
+        run_for_model!(dmg, $F, $rom);
+        run_for_model!(cgb, $F, $rom);
+    };
+
+    (dmg, $F:path, $rom:ident) => {
+        if let Err(e) = $F(gb_core::DeviceModel::Dmg, $rom) {
+            panic!("DMG failure: {e}");
+        }
+    };
+
+    (cgb, $F:path, $rom:ident) => {
+        if let Err(e) = $F(gb_core::DeviceModel::Cgb, $rom) {
+            panic!("CGB failure: {e}");
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! testcases_mooneye {
-    (
-        $name:ident($path:expr);
-    ) => {
+    ($name:ident($path:literal $(, $model:ident)?);) => {
         #[test]
         fn $name() {
             let rom = include_bytes!(concat!("../../../external/gameboy-test-roms/", "mooneye-test-suite/", $path));
-
-            let mut gb = GameBoy::new();
-            gb.load_cartridge(rom.to_vec()).unwrap();
-
-            run_until_break(&mut gb);
-            validate_fibonacci(&gb);
+            run_for_model!($($model, )? common::mooneye::run, rom);
         }
     };
 
     (
-        $name:ident($path:expr);
-        $(
-            $names:ident($paths:expr);
-        )+
+        $name:ident($path:literal $(, $model:ident)?);
+        $($names:ident($paths:literal $(, $models:ident)?);)+
     ) => {
-        testcases_mooneye! { $name($path); }
-        testcases_mooneye! {
-            $(
-                $names($paths);
-            )+
-        }
+        testcases_mooneye! { $name($path $(, $model)?); }
+        testcases_mooneye! { $($names($paths $(, $models)?);)+ }
     };
 }
 
 #[macro_export]
 macro_rules! testcases_blargg_serial {
-    (
-        $name:ident($path:expr);
-    ) => {
+    ($name:ident($path:literal $(, $model:ident)?);) => {
         #[test]
         fn $name() {
             let rom = include_bytes!(concat!("../../../external/gameboy-test-roms/", "blargg/", $path));
-
-            let mut gb = GameBoy::new();
-            gb.load_cartridge(rom.to_vec()).unwrap();
-
-            run_until_serial_passed(&mut gb);
+            run_for_model!($($model, )? common::blargg::run_serial, rom);
         }
     };
 
     (
-        $name:ident($path:expr);
-        $(
-            $names:ident($paths:expr);
-        )+
+        $name:ident($path:literal $(, $model:ident)?);
+        $($names:ident($paths:literal $(, $models:ident)?);)+
     ) => {
-        testcases_blargg_serial! { $name($path); }
-        testcases_blargg_serial! {
-            $(
-                $names($paths);
-            )+
-        }
+        testcases_blargg_serial! { $name($path $(, $model)?); }
+        testcases_blargg_serial! { $($names($paths $(, $models)?);)+ }
     };
 }
 
 #[macro_export]
 macro_rules! testcases_blargg_memory {
-    (
-        $name:ident($path:expr);
-    ) => {
+    ($name:ident($path:literal $(, $model:ident)?);) => {
         #[test]
         fn $name() {
             let rom = include_bytes!(concat!("../../../external/gameboy-test-roms/", "blargg/", $path));
-
-            let mut gb = GameBoy::new();
-            gb.load_cartridge(rom.to_vec()).unwrap();
-
-            run_until_memory_status(&mut gb);
+            run_for_model!($($model, )? common::blargg::run_memory, rom);
         }
     };
 
     (
-        $name:ident($path:expr);
-        $(
-            $names:ident($paths:expr);
-        )+
+        $name:ident($path:literal $(, $model:ident)?);
+        $($names:ident($paths:literal $(, $models:ident)?);)+
     ) => {
-        testcases_blargg_memory! { $name($path); }
-        testcases_blargg_memory! {
-            $(
-                $names($paths);
-            )+
-        }
+        testcases_blargg_memory! { $name($path $(, $model)?); }
+        testcases_blargg_memory! { $($names($paths $(, $models)?);)+ }
     };
 }

--- a/core/gb-core/tests/common/mod.rs
+++ b/core/gb-core/tests/common/mod.rs
@@ -1,5 +1,8 @@
 #![allow(dead_code)]
 
+pub mod blargg;
+pub mod error;
 pub mod macros;
+pub mod mooneye;
 pub mod runners;
 pub mod validators;

--- a/core/gb-core/tests/common/mooneye.rs
+++ b/core/gb-core/tests/common/mooneye.rs
@@ -1,0 +1,16 @@
+use gb_core::DeviceModel;
+
+use super::{
+    error::Error,
+    runners::{run_test, run_until_break},
+    validators::validate_fibonacci,
+};
+
+pub fn run(model: DeviceModel, rom: &'static [u8]) -> Result<(), Error> {
+    run_test(model, rom, |gb| {
+        run_until_break(gb)?;
+        validate_fibonacci(gb)?;
+
+        Ok(())
+    })
+}

--- a/core/gb-core/tests/common/runners.rs
+++ b/core/gb-core/tests/common/runners.rs
@@ -15,8 +15,9 @@ where
     F: FnOnce(&mut GameBoy) -> Result<(), Error>,
 {
     let mut gb = GameBoy::new(device_model);
-    gb.load_cartridge(rom.to_vec())?;
-
+    gb.insert_bootrom(None);
+    gb.insert_cartridge(rom.to_vec()).unwrap();
+    
     runner(&mut gb)?;
 
     Ok(())

--- a/core/gb-core/tests/common/runners.rs
+++ b/core/gb-core/tests/common/runners.rs
@@ -3,22 +3,40 @@ use std::{
     time::{Duration, Instant},
 };
 
-use gb_core::{GameBoy, MemoryInterface};
+use gb_core::{DeviceModel, GameBoy, MemoryInterface};
+
+use super::error::Error;
 
 const TIMEOUT: Duration = Duration::from_secs(20);
 const BREAK_OPCODE: u8 = 0x40; // LD B,B
 
-pub fn run_until_break(gb: &mut GameBoy) {
+pub fn run_test<F>(device_model: DeviceModel, rom: &'static [u8], runner: F) -> Result<(), Error>
+where
+    F: FnOnce(&mut GameBoy) -> Result<(), Error>,
+{
+    let mut gb = GameBoy::new(device_model);
+    gb.load_cartridge(rom.to_vec())?;
+
+    runner(&mut gb)?;
+
+    Ok(())
+}
+
+pub fn run_until_break(gb: &mut GameBoy) -> Result<(), Error> {
     let start_time = Instant::now();
 
     while gb.memory().read(gb.cpu().registers().pc) != BREAK_OPCODE {
         gb.step();
 
-        assert!(start_time.elapsed() <= TIMEOUT, "Timed out");
+        if start_time.elapsed() > TIMEOUT {
+            return Err(Error::Timeout);
+        }
     }
+
+    Ok(())
 }
 
-pub fn run_until_serial_passed(gb: &mut GameBoy) {
+pub fn run_until_serial_passed(gb: &mut GameBoy) -> Result<(), Error> {
     let (sender, receiver) = mpsc::channel::<u8>();
 
     let mut output = String::default();
@@ -36,15 +54,20 @@ pub fn run_until_serial_passed(gb: &mut GameBoy) {
         }
 
         if output.contains("Passed") {
-            break;
+            return Ok(());
         }
 
-        assert!(!output.contains("Failed"), "Failed");
-        assert!(start_time.elapsed() <= TIMEOUT, "Timed out");
+        if output.contains("Failed") {
+            return Err(Error::SerialOutputFailure(output));
+        }
+
+        if start_time.elapsed() > TIMEOUT {
+            return Err(Error::Timeout);
+        }
     }
 }
 
-pub fn run_until_memory_status(gb: &mut GameBoy) {
+pub fn run_until_memory_status(gb: &mut GameBoy) -> Result<(), Error> {
     let start_time = Instant::now();
 
     loop {
@@ -58,10 +81,15 @@ pub fn run_until_memory_status(gb: &mut GameBoy) {
             .collect::<String>();
 
         if output.contains("Passed") {
-            break;
+            return Ok(());
         }
 
-        assert!(!output.contains("Failed"), "Failed");
-        assert!(start_time.elapsed() <= TIMEOUT, "Timed out");
+        if output.contains("Failed") {
+            return Err(Error::MemoryOutputFailure(output));
+        }
+
+        if start_time.elapsed() > TIMEOUT {
+            return Err(Error::Timeout);
+        }
     }
 }

--- a/core/gb-core/tests/dmg_acid2.rs
+++ b/core/gb-core/tests/dmg_acid2.rs
@@ -1,30 +1,28 @@
 use common::{runners::run_until_break, validators::validate_screenshot};
-use gb_core::GameBoy;
+use gb_core::{DeviceModel, GameBoy};
 
 mod common;
 
-#[cfg(not(feature = "cgb"))]
 #[test]
 fn test_dmg_acid2_dmg() {
     let name = "dmg-acid2_dmg";
     let rom = include_bytes!("../../../external/gameboy-test-roms/dmg-acid2.gb");
 
-    let mut gb = GameBoy::new();
+    let mut gb = GameBoy::new(DeviceModel::Dmg);
     gb.load_cartridge(rom.to_vec()).unwrap();
 
-    run_until_break(&mut gb);
-    validate_screenshot(&gb, name);
+    run_until_break(&mut gb).unwrap();
+    validate_screenshot(&gb, name).unwrap();
 }
 
-#[cfg(feature = "cgb")]
 #[test]
 fn test_dmg_acid2_cgb() {
     let name = "dmg-acid2_cgb";
     let rom = include_bytes!("../../../external/gameboy-test-roms/dmg-acid2.gb");
 
-    let mut gb = GameBoy::new();
+    let mut gb = GameBoy::new(DeviceModel::Cgb);
     gb.load_cartridge(rom.to_vec()).unwrap();
 
-    run_until_break(&mut gb);
-    validate_screenshot(&gb, name);
+    run_until_break(&mut gb).unwrap();
+    validate_screenshot(&gb, name).unwrap();
 }

--- a/core/gb-core/tests/dmg_acid2.rs
+++ b/core/gb-core/tests/dmg_acid2.rs
@@ -9,7 +9,8 @@ fn test_dmg_acid2_dmg() {
     let rom = include_bytes!("../../../external/gameboy-test-roms/dmg-acid2.gb");
 
     let mut gb = GameBoy::new(DeviceModel::Dmg);
-    gb.load_cartridge(rom.to_vec()).unwrap();
+    gb.insert_bootrom(None);
+    gb.insert_cartridge(rom.to_vec()).unwrap();
 
     run_until_break(&mut gb).unwrap();
     validate_screenshot(&gb, name).unwrap();
@@ -21,7 +22,8 @@ fn test_dmg_acid2_cgb() {
     let rom = include_bytes!("../../../external/gameboy-test-roms/dmg-acid2.gb");
 
     let mut gb = GameBoy::new(DeviceModel::Cgb);
-    gb.load_cartridge(rom.to_vec()).unwrap();
+    gb.insert_bootrom(None);
+    gb.insert_cartridge(rom.to_vec()).unwrap();
 
     run_until_break(&mut gb).unwrap();
     validate_screenshot(&gb, name).unwrap();

--- a/core/gb-core/tests/mooneye.rs
+++ b/core/gb-core/tests/mooneye.rs
@@ -1,6 +1,3 @@
-use common::{runners::run_until_break, validators::validate_fibonacci};
-use gb_core::GameBoy;
-
 mod common;
 
 // Acceptance
@@ -20,7 +17,7 @@ testcases_mooneye! {
 
     // boot_regs_dmg0("acceptance/boot_regs-dmg0.gb"); // DMG0 is unsupported.
 
-    // boot_regs_dmg_abc("acceptance/boot_regs-dmgABC.gb"); // DMG only. Tested separately.
+    boot_regs_dmg_abc("acceptance/boot_regs-dmgABC.gb", dmg); // DMG only.
 
     // boot_regs_mgb("acceptance/boot_regs-mgb.gb"); // MGB is unsupported.
     // boot_regs_sgb("acceptance/boot_regs-sgb.gb"); // SGB is unsupported.
@@ -128,32 +125,10 @@ testcases_mooneye! {
 }
 
 // Acceptance
-// DMG only tests.
-#[cfg(not(feature = "cgb"))]
-testcases_mooneye! {
-    boot_regs_dmg_abc("acceptance/boot_regs-dmgABC.gb");
-}
-
-// Acceptance
 // DMG only tests (bootrom is unsupported).
-#[cfg(not(any(feature = "cgb", feature = "bootrom")))]
+#[cfg(not(feature = "bootrom"))]
 testcases_mooneye! {
-    boot_hwio_dmg_abc_mgb("acceptance/boot_hwio-dmgABCmgb.gb");
-}
-
-// Misc
-// CGB only tests.
-#[cfg(feature = "cgb")]
-testcases_mooneye! {
-    boot_regs_cgb("misc/boot_regs-cgb.gb");
-}
-
-// Misc
-// CGB only tests (needs bootrom).
-#[cfg(all(feature = "cgb", feature = "bootrom"))]
-testcases_mooneye! {
-    boot_div_cgb_abcde("misc/boot_div-cgbABCDE.gb");
-    boot_hwio_c("misc/boot_hwio-C.gb"); // Why is this failing without the bootrom?
+    boot_hwio_dmg_abc_mgb("acceptance/boot_hwio-dmgABCmgb.gb", dmg);
 }
 
 // TODO: compare screenshots
@@ -162,21 +137,29 @@ testcases_mooneye! {
 //     sprite_priority("manual-only/sprite_priority.gb");
 // }
 
-// misc
-// testcases_mooneye! {
-// boot_div_a("misc/boot_div-A.gb"); // AGS is unsupported.
+// Misc
+testcases_mooneye! {
+    // boot_div_a("misc/boot_div-A.gb"); // AGS is unsupported.
 
-// boot_div_cgb0("misc/boot_div-cgb0.gb"); // CGB0 is unsupported.
+    // boot_div_cgb0("misc/boot_div-cgb0.gb"); // CGB0 is unsupported.
 
-// boot_div_cgb_abcde("misc/boot_div-cgbABCDE.gb"); // CGB only. Tested separately.
-// boot_hwio_c("misc/boot_hwio-C.gb"); // CGB only. Tested separately.
+    // boot_div_cgb_abcde("misc/boot_div-cgbABCDE.gb"); // CGB only. Tested separately.
+    // boot_hwio_c("misc/boot_hwio-C.gb"); // CGB only. Tested separately.
 
-// boot_regs_a("misc/boot_regs-A.gb"); // AGS is unsupported.
+    // boot_regs_a("misc/boot_regs-A.gb"); // AGS is unsupported.
 
-// boot_regs_cgb("misc/boot_regs-cgb.gb"); // CGB only. Tested separately.
-// bits_unused_hwio_c("misc/bits/unused_hwio-C.gb");  // TODO: why is this failing?
-// ppu_vblank_stat_intr_c("misc/ppu/vblank_stat_intr-C.gb");
-// }
+    boot_regs_cgb("misc/boot_regs-cgb.gb", cgb); // CGB only.
+    // bits_unused_hwio_c("misc/bits/unused_hwio-C.gb");  // TODO: why is this failing?
+    // ppu_vblank_stat_intr_c("misc/ppu/vblank_stat_intr-C.gb");
+}
+
+// Misc
+// CGB only tests (requires bootrom).
+#[cfg(feature = "bootrom")]
+testcases_mooneye! {
+    boot_div_cgb_abcde("misc/boot_div-cgbABCDE.gb", cgb);
+    boot_hwio_c("misc/boot_hwio-C.gb", cgb); // Why is this failing without the bootrom?
+}
 
 // From: https://github.com/Gekkio/mooneye-test-suite
 //

--- a/platform/eframe/Cargo.toml
+++ b/platform/eframe/Cargo.toml
@@ -7,9 +7,7 @@ edition = "2021"
 workspace = true
 
 [features]
-# default = ["bootrom", "cgb"]
 bootrom = ["gb-core/bootrom"]
-cgb = ["gb-core/cgb"]
 
 [dependencies]
 clap = { version = "4.5.1", features = ["derive"] }

--- a/platform/eframe/src/app.rs
+++ b/platform/eframe/src/app.rs
@@ -18,9 +18,17 @@ impl App {
     pub fn new(
         cc: &eframe::CreationContext,
         device_model: DeviceModel,
+        bootrom_path: Option<String>,
         rom_path: Option<String>,
     ) -> Self {
         let mut gb = GameBoy::new(device_model);
+
+        if let Some(path) = &bootrom_path {
+            let bootrom = std::fs::read(path).unwrap();
+            gb.insert_bootrom(Some(bootrom));
+        } else {
+            gb.insert_bootrom(None);
+        }
 
         // Maybe let the UI handle the errors?
         let rom_path = {
@@ -37,7 +45,7 @@ impl App {
 
         let rom = std::fs::read(&rom_path).unwrap();
 
-        gb.load_cartridge(rom).unwrap();
+        gb.insert_cartridge(rom).unwrap();
         load_battery(&mut gb, &rom_path);
 
         Self {

--- a/platform/eframe/src/app.rs
+++ b/platform/eframe/src/app.rs
@@ -1,5 +1,5 @@
 use egui::ViewportCommand;
-use gb_core::{Button, GameBoy, EXTENSIONS, EXTENSIONS_DESCRIPTION};
+use gb_core::{Button, DeviceModel, GameBoy, EXTENSIONS, EXTENSIONS_DESCRIPTION};
 
 use crate::{
     cartridge::{load_battery, save_battery},
@@ -15,8 +15,12 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(cc: &eframe::CreationContext, rom_path: Option<String>) -> Self {
-        let mut gb = GameBoy::new();
+    pub fn new(
+        cc: &eframe::CreationContext,
+        device_model: DeviceModel,
+        rom_path: Option<String>,
+    ) -> Self {
+        let mut gb = GameBoy::new(device_model);
 
         // Maybe let the UI handle the errors?
         let rom_path = {

--- a/platform/eframe/src/gui/tiles.rs
+++ b/platform/eframe/src/gui/tiles.rs
@@ -8,6 +8,7 @@ use egui::{
     Window,
 };
 use gb_core::{
+    DeviceModel,
     GameBoy,
     TileDataFrame,
     TILE_DATA_FRAME_HEIGHT,
@@ -90,12 +91,13 @@ impl Tiles {
             .vram
             .draw_tile_data_0_into_frame(self.pixels.as_mut());
 
-        #[cfg(feature = "cgb")]
-        gb_ctx
-            .memory()
-            .ppu
-            .vram
-            .draw_tile_data_1_into_frame(self.pixels.as_mut());
+        if gb_ctx.device_model == DeviceModel::Cgb {
+            gb_ctx
+                .memory()
+                .ppu
+                .vram
+                .draw_tile_data_1_into_frame(self.pixels.as_mut());
+        }
 
         let image = ColorImage::from_rgba_unmultiplied(
             [TILE_DATA_FRAME_WIDTH, TILE_DATA_FRAME_HEIGHT],

--- a/platform/eframe/src/main.rs
+++ b/platform/eframe/src/main.rs
@@ -5,9 +5,13 @@ use gb_core::{DeviceModel, SCREEN_HEIGHT, SCREEN_WIDTH};
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Set the device type to CGB
+    /// Set the device model to CGB
     #[arg(short, long, default_value_t = false)]
     cgb: bool,
+
+    /// Optional bootrom path
+    #[arg(short, long)]
+    bootrom: Option<String>,
 
     /// Optional ROM path (will show file picker if not provided)
     rom: Option<String>,
@@ -26,6 +30,7 @@ fn main() -> Result<(), eframe::Error> {
     } else {
         DeviceModel::Dmg
     };
+    let bootrom_path = args.bootrom;
     let rom_path = args.rom;
 
     #[allow(clippy::cast_precision_loss)]
@@ -39,7 +44,7 @@ fn main() -> Result<(), eframe::Error> {
     eframe::run_native(
         "gameboy-emulator",
         native_options,
-        Box::new(move |cc| Box::new(App::new(cc, device_model, rom_path))),
+        Box::new(move |cc| Box::new(App::new(cc, device_model, bootrom_path, rom_path))),
     )
 }
 

--- a/platform/eframe/src/main.rs
+++ b/platform/eframe/src/main.rs
@@ -1,16 +1,16 @@
 use app::App;
 use clap::Parser;
-use gb_core::{SCREEN_HEIGHT, SCREEN_WIDTH};
+use gb_core::{DeviceModel, SCREEN_HEIGHT, SCREEN_WIDTH};
 
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Optional ROM path (will show file picker if not provided)
-    rom: Option<String>,
-
-    /// (Unused) Set the device type to CGB
+    /// Set the device type to CGB
     #[arg(short, long, default_value_t = false)]
     cgb: bool,
+
+    /// Optional ROM path (will show file picker if not provided)
+    rom: Option<String>,
 }
 
 fn main() -> Result<(), eframe::Error> {
@@ -21,6 +21,11 @@ fn main() -> Result<(), eframe::Error> {
 
     let args = Args::parse();
 
+    let device_model = if args.cgb {
+        DeviceModel::Cgb
+    } else {
+        DeviceModel::Dmg
+    };
     let rom_path = args.rom;
 
     #[allow(clippy::cast_precision_loss)]
@@ -34,7 +39,7 @@ fn main() -> Result<(), eframe::Error> {
     eframe::run_native(
         "gameboy-emulator",
         native_options,
-        Box::new(move |cc| Box::new(App::new(cc, rom_path))),
+        Box::new(move |cc| Box::new(App::new(cc, device_model, rom_path))),
     )
 }
 

--- a/platform/libretro/Cargo.toml
+++ b/platform/libretro/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["cdylib"]
 
 [features]
 bootrom = ["gb-core/bootrom"]
-cgb = ["gb-core/cgb"]
 
 [dependencies]
 env_logger = "0.11.2"

--- a/platform/libretro/src/lib.rs
+++ b/platform/libretro/src/lib.rs
@@ -1,4 +1,12 @@
-use gb_core::{Button, GameBoy, ScreenPixels, SCREEN_HEIGHT, SCREEN_PIXELS_SIZE, SCREEN_WIDTH};
+use gb_core::{
+    Button,
+    DeviceModel,
+    GameBoy,
+    ScreenPixels,
+    SCREEN_HEIGHT,
+    SCREEN_PIXELS_SIZE,
+    SCREEN_WIDTH,
+};
 use key_mappings::LibretroKeyMappings;
 use libretro_rs::{
     libretro_core,
@@ -25,7 +33,7 @@ impl RetroCore for Emulator {
         env_logger::init();
 
         Self {
-            gb: GameBoy::default(),
+            gb: GameBoy::new(DeviceModel::Cgb),
             pixels: vec![0; SCREEN_PIXELS_SIZE]
                 .into_boxed_slice()
                 .try_into()

--- a/platform/libretro/src/lib.rs
+++ b/platform/libretro/src/lib.rs
@@ -87,7 +87,8 @@ impl RetroCore for Emulator {
             }
         };
 
-        let result = self.gb.load_cartridge(rom);
+        self.gb.insert_bootrom(None);
+        let result = self.gb.insert_cartridge(rom);
 
         match result {
             Ok(()) => RetroLoadGameResult::Success {

--- a/platform/pixels/src/app.rs
+++ b/platform/pixels/src/app.rs
@@ -32,7 +32,8 @@ impl App {
 
         let rom = std::fs::read(rom_path).unwrap();
 
-        gb.load_cartridge(rom).unwrap();
+        gb.insert_bootrom(None);
+        gb.insert_cartridge(rom).unwrap();
         // load_battery(&mut gb, &rom_path);
 
         Self {

--- a/platform/pixels/src/app.rs
+++ b/platform/pixels/src/app.rs
@@ -1,5 +1,5 @@
 use egui::ViewportCommand;
-use gb_core::{Button, GameBoy, EXTENSIONS, EXTENSIONS_DESCRIPTION};
+use gb_core::{Button, DeviceModel, GameBoy, EXTENSIONS, EXTENSIONS_DESCRIPTION};
 
 use crate::{egui_framework::EguiUi, gui::Gui, key_mappings};
 
@@ -10,8 +10,12 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(egui_ctx: &egui::Context, rom_path: Option<String>) -> Self {
-        let mut gb = GameBoy::new();
+    pub fn new(
+        egui_ctx: &egui::Context,
+        device_model: DeviceModel,
+        rom_path: Option<String>,
+    ) -> Self {
+        let mut gb = GameBoy::new(device_model);
 
         // Maybe let the UI handle the errors?
         let rom_path = {

--- a/platform/pixels/src/gui/tiles.rs
+++ b/platform/pixels/src/gui/tiles.rs
@@ -8,6 +8,7 @@ use egui::{
     Window,
 };
 use gb_core::{
+    DeviceModel,
     GameBoy,
     TileDataFrame,
     TILE_DATA_FRAME_HEIGHT,
@@ -90,12 +91,13 @@ impl Tiles {
             .vram
             .draw_tile_data_0_into_frame(self.pixels.as_mut());
 
-        #[cfg(feature = "cgb")]
-        gb_ctx
-            .memory()
-            .ppu
-            .vram
-            .draw_tile_data_1_into_frame(self.pixels.as_mut());
+        if gb_ctx.device_model == DeviceModel::Cgb {
+            gb_ctx
+                .memory()
+                .ppu
+                .vram
+                .draw_tile_data_1_into_frame(self.pixels.as_mut());
+        }
 
         let image = ColorImage::from_rgba_unmultiplied(
             [TILE_DATA_FRAME_WIDTH, TILE_DATA_FRAME_HEIGHT],

--- a/platform/pixels/src/main.rs
+++ b/platform/pixels/src/main.rs
@@ -1,7 +1,7 @@
 use app::App;
 use clap::Parser;
 use error_iter::ErrorIter as _;
-use gb_core::{SCREEN_HEIGHT, SCREEN_WIDTH};
+use gb_core::{DeviceModel, SCREEN_HEIGHT, SCREEN_WIDTH};
 use log::error;
 use pixels::{Error, Pixels, SurfaceTexture};
 use winit::{
@@ -24,12 +24,12 @@ mod utils;
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Optional ROM path (will show file picker if not provided)
-    rom: Option<String>,
-
-    /// (Unused) Set the device type to CGB
+    /// Set the device model to CGB
     #[arg(short, long, default_value_t = false)]
     cgb: bool,
+
+    /// Optional ROM path (will show file picker if not provided)
+    rom: Option<String>,
 }
 
 fn main() -> Result<(), Error> {
@@ -40,6 +40,11 @@ fn main() -> Result<(), Error> {
 
     let args = Args::parse();
 
+    let device_model = if args.cgb {
+        DeviceModel::Cgb
+    } else {
+        DeviceModel::Dmg
+    };
     let rom_path = args.rom;
 
     #[allow(clippy::cast_precision_loss)]
@@ -80,7 +85,7 @@ fn main() -> Result<(), Error> {
     };
 
     // let mut gui = Gui::new();
-    let mut app = App::new(&egui_framework.egui_ctx, rom_path);
+    let mut app = App::new(&egui_framework.egui_ctx, device_model, rom_path);
 
     let result = event_loop.run(|event, elwt| {
         // Handle input events

--- a/platform/sdl2-rust/Cargo.toml
+++ b/platform/sdl2-rust/Cargo.toml
@@ -8,7 +8,6 @@ workspace = true
 
 [features]
 bootrom = ["gb-core/bootrom"]
-cgb = ["gb-core/cgb"]
 
 [dependencies]
 clap = { version = "4.5.1", features = ["derive"] }

--- a/platform/sdl2-rust/src/main.rs
+++ b/platform/sdl2-rust/src/main.rs
@@ -1,16 +1,16 @@
 use app::App;
 use clap::Parser;
-use gb_core::GameBoy;
+use gb_core::{DeviceModel, GameBoy};
 
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Optional ROM path (will show file picker if not provided)
-    rom: Option<String>,
-
-    /// (Unused) Set the device type to CGB
+    /// Set the device model to CGB
     #[arg(short, long, default_value_t = false)]
     cgb: bool,
+
+    /// Optional ROM path (will show file picker if not provided)
+    rom: Option<String>,
 }
 
 fn main() {
@@ -21,8 +21,13 @@ fn main() {
 
     let args = Args::parse();
 
+    let device_model = if args.cgb {
+        DeviceModel::Cgb
+    } else {
+        DeviceModel::Dmg
+    };
     let rom_path = args.rom;
-    let gb = GameBoy::new();
+    let gb = GameBoy::new(device_model);
 
     App::new(gb, rom_path).run();
 }

--- a/platform/sdl2-rust/src/main.rs
+++ b/platform/sdl2-rust/src/main.rs
@@ -9,6 +9,10 @@ struct Args {
     #[arg(short, long, default_value_t = false)]
     cgb: bool,
 
+    /// Optional bootrom path
+    #[arg(short, long)]
+    bootrom: Option<String>,
+
     /// Optional ROM path (will show file picker if not provided)
     rom: Option<String>,
 }
@@ -26,10 +30,11 @@ fn main() {
     } else {
         DeviceModel::Dmg
     };
+    let bootrom_path = args.bootrom;
     let rom_path = args.rom;
     let gb = GameBoy::new(device_model);
 
-    App::new(gb, rom_path).run();
+    App::new(gb, bootrom_path, rom_path).run();
 }
 
 mod app;


### PR DESCRIPTION
Removes the need to rebuild when selecting the crate features. This is a work in progress as some cleaning up is still needed.